### PR TITLE
Add encoding to top of file to prevent issues running it

### DIFF
--- a/portgres_rce.py
+++ b/portgres_rce.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import psycopg2
 from psycopg2.extras import RealDictCursor
 import multiprocessing


### PR DESCRIPTION
If this line is not added, python complained about non-ascii characters
```bash
python portgres_rce.py 
  File "portgres_rce.py", line 10
SyntaxError: Non-ASCII character '\xed' in file portgres_rce.py on line 10, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```